### PR TITLE
Faster Terrain

### DIFF
--- a/components/boundarySidebar.js
+++ b/components/boundarySidebar.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import Terrain from './terrain';
 import TrailTypes from './trailTypes';
 import HorizontalBarGraph from './horizontalBarGraph';
 import BoundaryTotals from './boundaryTotals';
@@ -12,13 +11,6 @@ import spacing from '../styles/spacing.css';
 import ImportantWeather from './importantWeather';
 
 const BoundarySidebar = ({id, hasElevationData, vertices, area, trails, trailTypes, trailLengths, bounds, trailsCount, hasWeatherData, weatherData, hasSatelliteImage, satelliteImageUrl}) => {
-  const terrain = () => {
-    return <Terrain
-      index={`boundary:${id}`}
-      satelliteImageUrl={satelliteImageUrl}
-      vertices={vertices}/>
-  }
-
   const boundaryTotals = () => {
     if (hasElevationData) {
       return <BoundaryTotals

--- a/components/boundarySidebar.js
+++ b/components/boundarySidebar.js
@@ -10,7 +10,7 @@ import label from '../styles/label.css';
 import spacing from '../styles/spacing.css';
 import ImportantWeather from './importantWeather';
 
-const BoundarySidebar = ({id, hasElevationData, vertices, area, trails, trailTypes, trailLengths, bounds, trailsCount, hasWeatherData, weatherData, hasSatelliteImage, satelliteImageUrl}) => {
+const BoundarySidebar = ({id, hasElevationData, vertices, area, trails, trailTypes, trailLengths, bounds, trailsCount, hasWeatherData, weatherData}) => {
   const boundaryTotals = () => {
     if (hasElevationData) {
       return <BoundaryTotals
@@ -87,8 +87,6 @@ BoundarySidebar.propTypes = {
   bounds: PropTypes.array,
   hasWeatherData: PropTypes.bool,
   weatherData: PropTypes.object,
-  hasSatelliteImage: PropTypes.bool,
-  satelliteImageUrl: PropTypes.string
 };
 
 export default BoundarySidebar;

--- a/components/boundarySidebar.js
+++ b/components/boundarySidebar.js
@@ -11,14 +11,12 @@ import label from '../styles/label.css';
 import spacing from '../styles/spacing.css';
 import ImportantWeather from './importantWeather';
 
-const BoundarySidebar = ({id, hasElevationData, dump, area, trails, trailTypes, trailLengths, bounds, trailsCount, hasWeatherData, weatherData}) => {
+const BoundarySidebar = ({id, hasElevationData, dump, area, trails, trailTypes, trailLengths, bounds, trailsCount, hasWeatherData, weatherData, hasSatelliteImage, satelliteImageUrl}) => {
   const terrain = () => {
-    if (hasElevationData) {
+    if (hasElevationData && hasSatelliteImage) {
       return <Terrain
         index={`boundary:${id}`}
-        height={dump.height}
-        width={dump.width}
-        bounds={bounds}
+        satelliteImageUrl={satelliteImageUrl}
         vertices={dump.vertices}/>
     }
   }
@@ -98,7 +96,10 @@ BoundarySidebar.propTypes = {
   trailTypes: PropTypes.object,
   trailLengths: PropTypes.array,
   bounds: PropTypes.array,
-  weatherData: PropTypes.object
+  hasWeatherData: PropTypes.bool,
+  weatherData: PropTypes.object,
+  hasSatelliteImage: PropTypes.bool,
+  satelliteImageUrl: PropTypes.string
 };
 
 export default BoundarySidebar;

--- a/components/boundarySidebar.js
+++ b/components/boundarySidebar.js
@@ -11,14 +11,12 @@ import label from '../styles/label.css';
 import spacing from '../styles/spacing.css';
 import ImportantWeather from './importantWeather';
 
-const BoundarySidebar = ({id, hasElevationData, dump, area, trails, trailTypes, trailLengths, bounds, trailsCount, hasWeatherData, weatherData, hasSatelliteImage, satelliteImageUrl}) => {
+const BoundarySidebar = ({id, hasElevationData, vertices, area, trails, trailTypes, trailLengths, bounds, trailsCount, hasWeatherData, weatherData, hasSatelliteImage, satelliteImageUrl}) => {
   const terrain = () => {
-    if (hasElevationData && hasSatelliteImage) {
-      return <Terrain
-        index={`boundary:${id}`}
-        satelliteImageUrl={satelliteImageUrl}
-        vertices={dump.vertices}/>
-    }
+    return <Terrain
+      index={`boundary:${id}`}
+      satelliteImageUrl={satelliteImageUrl}
+      vertices={vertices}/>
   }
 
   const boundaryTotals = () => {
@@ -26,7 +24,7 @@ const BoundarySidebar = ({id, hasElevationData, dump, area, trails, trailTypes, 
       return <BoundaryTotals
         area={area}
         trailsCount={trailsCount}
-        highPoint={Math.max(...dump.vertices)}/>
+        highPoint={Math.max(...vertices)}/>
     }
   }
 
@@ -75,7 +73,6 @@ const BoundarySidebar = ({id, hasElevationData, dump, area, trails, trailTypes, 
 
   return (
     <div className={styles.boundarySidebar}>
-      {terrain()}
       {boundaryTotals()}
       <div className={styles.boundarySidebarGridLayout}>
         {trailTypesBreakdown()}

--- a/components/loadingSpinner.js
+++ b/components/loadingSpinner.js
@@ -1,7 +1,7 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 
-const LoadingSpinner = () => {
-
+const LoadingSpinner = ({speed}) => {
   return (
     <svg viewBox="0 0 64 64">
         <g>
@@ -14,11 +14,15 @@ const LoadingSpinner = () => {
           <g strokeWidth="4" strokeLinecap="round" fill="none" transform="rotate(82.912 32 32)">
           <path stroke="url(#sGD)" d="M4,32 c0,15,12,28,28,28c8,0,16-4,21-9"></path>
           <path d="M60,32 C60,16,47.464,4,32,4S4,16,4,32"></path>
-          <animateTransform values="0,32,32;360,32,32" attributeName="transform" type="rotate" repeatCount="indefinite" dur="750ms"></animateTransform>
+          <animateTransform values="0,32,32;360,32,32" attributeName="transform" type="rotate" repeatCount="indefinite" dur={speed}></animateTransform>
           </g>
         </g>
       </svg>
   )
 };
 
-export default loadingSpinner;
+LoadingSpinner.propTypes = {
+  speed: PropTypes.string
+};
+
+export default LoadingSpinner;

--- a/components/sidebar.js
+++ b/components/sidebar.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import TrailSidebar from './trailSidebar';
 import BoundarySidebar from './boundarySidebar';
+import Terrain from './terrain';
 import cx from 'classnames';
 import styles from '../styles/sidebar.css';
 import spacing from '../styles/spacing.css';
@@ -10,6 +11,12 @@ const Sidebar = ({trails, boundary, handles}) => {
   const trailOrBoundary = () => {
     if (trails && trails.length) return <TrailSidebar firstTrail={trails[0]} trails={trails} handles={handles}/>
     if (boundary && boundary.selected) return <BoundarySidebar {...boundary}/>
+  }
+
+  const terrain = () => {
+    return <Terrain
+      satelliteImageUrl={(trails[0] || boundary || {}).satelliteImageUrl}
+      vertices={(trails[0] || boundary || {}).vertices}/>
   }
 
   const hasContent = () => ((boundary && boundary.selected) || (trails && trails.some(t => t.selected)))
@@ -23,6 +30,9 @@ const Sidebar = ({trails, boundary, handles}) => {
     <div className={cx(styles.body, {[styles.active]: hasContent()})}>
       <div className={styles.content}>
         <div className={styles.title}>{name()}</div>
+        <div style={{display: (trails.length > 1) ? 'none' : 'block'}}>
+          {terrain()}
+        </div>
         {trailOrBoundary()}
       </div>
     </div>

--- a/components/terrain.js
+++ b/components/terrain.js
@@ -12,12 +12,17 @@ export default class Terrain extends React.Component {
   drawMap() {
     let vertices = this.props.vertices;
     const size = Math.sqrt(vertices.length) - 1;
-    const texture = new TextureLoader().load(this.props.satelliteImageUrl);
     const geometry = new PlaneGeometry(200, 200, size, size);
-    const material = new MeshBasicMaterial({map: texture});
-    const plane = new Mesh(geometry, material);
+    const material = new MeshBasicMaterial();
+    const mesh = new Mesh(geometry, material);
 
-    plane.geometry.vertices.map((v,i) => {
+    const texture = new TextureLoader().load(this.props.satelliteImageUrl, function(img){
+      mesh.material.map = img;
+      mesh.material.needsUpdate = true;
+      this.renderMap();
+    }.bind(this));
+
+    mesh.geometry.vertices.map((v,i) => {
       let z = vertices[i];
       if (z == null || z == NaN || z == undefined) {
         z = vertices[i - 1] || vertices[i + 1] || vertices[i - this.props.height] || vertices[i + this.props.height];
@@ -25,9 +30,10 @@ export default class Terrain extends React.Component {
       return Object.assign(v, { z: z / 100 })
     });
 
-    plane.rotation.x = 5.7;
+    mesh.rotation.x = 5.7;
 
-    this.scene.add(plane);
+    this.scene.add(mesh);
+    this.renderMap();
   }
 
   clearMap() {
@@ -53,11 +59,8 @@ export default class Terrain extends React.Component {
 
     this.renderMap = function() {
       renderer.render(this.scene, camera);
+      console.log("render called")
     }
-
-    DefaultLoadingManager.onLoad = function() {
-      this.renderMap();
-    }.bind(this);
 
     this.initialized = true;
   }

--- a/components/terrain.js
+++ b/components/terrain.js
@@ -62,15 +62,20 @@ export default class Terrain extends React.Component {
     Object.assign(this, {scene, renderer, camera, mesh});
   }
 
+  isVisible() {
+    return (this.props.vertices && this.props.satelliteImageUrl);
+  }
+
   componentDidUpdate(prevProps) {
     if (this.props.vertices && prevProps.vertices !== this.props.vertices) {
-      this.updateVertices(this.mesh, this.props.vertices);
-      this.renderScene({...this});
+      this.updateVertices(this.mesh, this.props.vertices).then(() => {
+        this.renderScene({...this});
+      });
     }
 
     if (this.props.satelliteImageUrl && prevProps.satelliteImageUrl !== this.props.satelliteImageUrl) {
       this.updateSatelliteImage(this.mesh, this.props.satelliteImageUrl).then(() => {
-          this.renderScene({...this});
+        this.renderScene({...this});
       });
     }
   }
@@ -78,7 +83,7 @@ export default class Terrain extends React.Component {
   render() {
     return (
       <div ref="canvasContainer" className={cx(styles.terrain, styles.center)}>
-        <canvas ref="canvas" className={styles.canvas}></canvas>
+        <canvas ref="canvas" className={cx(styles.canvas, {[styles.visible]: this.isVisible()})}></canvas>
       </div>
     )
   }

--- a/components/terrain.js
+++ b/components/terrain.js
@@ -14,20 +14,16 @@ export default class Terrain extends React.Component {
       mesh.geometry.vertices.map((v,i) => Object.assign(v, { z: this.props.vertices[i] / 100 }));
       mesh.rotation.x = 5.7;
 
-      new TextureLoader().load(this.props.satelliteImageUrl, function(img){
+      new TextureLoader().load(this.props.satelliteImageUrl, (img) => {
         mesh.material.map = img;
         mesh.material.needsUpdate = true;
         resolve();
-      }.bind(this));
+      });
     });
   }
 
-  clearMap() {
-    this.scene.children.forEach(function(object) {
-      this.scene.remove(object);
-    }.bind(this));
-
-    this.renderMap();
+  clearMap(scene) {
+    scene.children.forEach((object) => scene.remove(object));
   }
 
   createMesh(scene) {
@@ -51,22 +47,23 @@ export default class Terrain extends React.Component {
     return {scene, renderer, camera};
   }
 
-  draw() {
-    this.clearMap();
-    this.drawMap();
-  }
-
   componentDidMount() {
     const {scene, renderer, camera} = this.initializeCanvas();
     const mesh = this.createMesh();
     scene.add(mesh);
-    this.updateMesh(mesh).then(() => {
-      renderer.render(scene, camera)
-    });
+    this.updateMesh(mesh).then(() => renderer.render(scene, camera));
+    Object.assign({}, this, {scene, renderer, camera, mesh});
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.index !== prevProps.index) this.drawMap();
+    if (this.props.index == prevProps.index) return;
+
+    this.clearMap(this.scene);
+    renderer.render(this.scene, this.camera);
+
+    this.updateMesh(this.mesh).then(() => {
+      renderer.render(this.scene, this.camera);
+    });
   }
 
   render() {

--- a/components/terrain.js
+++ b/components/terrain.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {WebGLRenderer, Scene, PerspectiveCamera, TextureLoader, PlaneGeometry, MeshBasicMaterial, Mesh, DefaultLoadingManager} from 'three';
+import {WebGLRenderer, Scene, PerspectiveCamera, TextureLoader, PlaneGeometry, MeshBasicMaterial, Mesh} from 'three';
 import styles from '../styles/terrain.css';
 import center from '../styles/center.css';
 import cx from 'classnames';
@@ -85,7 +85,6 @@ export default class Terrain extends React.Component {
 };
 
 Terrain.propTypes = {
-  index: PropTypes.string,
   vertices: PropTypes.array,
   satelliteImageUrl: PropTypes.string
 }

--- a/components/terrain.js
+++ b/components/terrain.js
@@ -10,30 +10,20 @@ import _ from 'underscore';
 export default class Terrain extends React.Component {
 
   drawMap() {
-    let vertices = this.props.vertices;
-    const size = Math.sqrt(vertices.length) - 1;
+    const size = Math.sqrt(this.props.vertices.length) - 1;
     const geometry = new PlaneGeometry(200, 200, size, size);
     const material = new MeshBasicMaterial();
     const mesh = new Mesh(geometry, material);
 
-    const texture = new TextureLoader().load(this.props.satelliteImageUrl, function(img){
-      mesh.material.map = img;
-      mesh.material.needsUpdate = true;
-      this.renderMap();
-    }.bind(this));
-
-    mesh.geometry.vertices.map((v,i) => {
-      let z = vertices[i];
-      if (z == null || z == NaN || z == undefined) {
-        z = vertices[i - 1] || vertices[i + 1] || vertices[i - this.props.height] || vertices[i + this.props.height];
-      };
-      return Object.assign(v, { z: z / 100 })
-    });
-
+    mesh.geometry.vertices.map((v,i) => Object.assign(v, { z: this.props.vertices[i] / 100 }));
     mesh.rotation.x = 5.7;
 
-    this.scene.add(mesh);
-    this.renderMap();
+    new TextureLoader().load(this.props.satelliteImageUrl, function(img){
+      mesh.material.map = img;
+      mesh.material.needsUpdate = true;
+      this.scene.add(mesh);
+      this.renderMap();
+    }.bind(this));
   }
 
   clearMap() {

--- a/components/terrain.js
+++ b/components/terrain.js
@@ -11,7 +11,7 @@ import _ from 'underscore';
 export default class Terrain extends React.Component {
 
   getEarth() {
-    fetch(new Request(`/api/terrain/${this.view.center.join("/")}/${this.view.zoom}`)).then((r) => r.json()).then(function(resp) {
+    fetch(`/api/terrain/${this.view.center.join("/")}/${this.view.zoom}`).then((r) => r.blob()).then(function(resp) {
       this.earth = resp;
       this.drawMap();
     }.bind(this));
@@ -21,13 +21,11 @@ export default class Terrain extends React.Component {
     if (!this.earth) return;
 
     let vertices = this.props.vertices;
-    const loader = new TextureLoader();
-    loader.crossOrigin = '';
-    const texture = loader.load(this.earth.url);
+    const texture = new TextureLoader().load(URL.createObjectURL(this.earth));
     const geometry = new PlaneGeometry(200, 200, this.props.height - 1, this.props.width - 1);
     const material = new MeshBasicMaterial({map: texture});
     const plane = new Mesh(geometry, material);
-            
+
     plane.geometry.vertices.map((v,i) => {
       let z = vertices[i];
       if (z == null || z == NaN || z == undefined) {
@@ -56,11 +54,11 @@ export default class Terrain extends React.Component {
     this.scene = new Scene({autoUpdate: false});
 
     const aspectRatio = this.refs.canvasContainer.offsetWidth / this.refs.canvasContainer.offsetHeight;
-    
-    const camera = new PerspectiveCamera(52 / aspectRatio, aspectRatio, 0.1, 1000);    
+
+    const camera = new PerspectiveCamera(52 / aspectRatio, aspectRatio, 0.1, 1000);
     camera.position.y = -20;
     camera.position.z = 200;
-    
+
     const renderer = new WebGLRenderer({canvas: this.refs.canvas});
     renderer.setPixelRatio(window.devicePixelRatio ? window.devicePixelRatio : 1);
     renderer.setSize(this.refs.canvasContainer.offsetWidth, this.refs.canvasContainer.offsetHeight);
@@ -75,20 +73,20 @@ export default class Terrain extends React.Component {
 
     this.initialized = true;
   }
-  
+
   draw() {
     this.view = GeoViewport.viewport(_.flatten(this.props.bounds), [1024, 1024], 12, 14);
 
     this.clearMap();
     this.getEarth();
   }
-  
+
   componentDidMount() {
     this.initializeCanvas();
     this.draw()
   }
 
-  componentDidUpdate(prevProps) {    
+  componentDidUpdate(prevProps) {
     if (this.props.index !== prevProps.index) this.draw();
   }
 

--- a/components/terrain.js
+++ b/components/terrain.js
@@ -5,6 +5,7 @@ import styles from '../styles/terrain.css';
 import center from '../styles/center.css';
 import cx from 'classnames';
 import _ from 'underscore';
+import LoadingSpinner from './loadingSpinner';
 
 
 export default class Terrain extends React.Component {
@@ -84,6 +85,7 @@ export default class Terrain extends React.Component {
     return (
       <div ref="canvasContainer" className={cx(styles.terrain, styles.center)}>
         <canvas ref="canvas" className={cx(styles.canvas, {[styles.visible]: this.isVisible()})}></canvas>
+        <div className={cx(styles.loadingSpinner, {[styles.visible]: !this.isVisible()})}><LoadingSpinner speed="1s"/></div>
       </div>
     )
   }

--- a/components/trailSidebar.js
+++ b/components/trailSidebar.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import ElevationTotals from './elevationTotals';
-import Terrain from './terrain';
 import TrailListContainer from './trailListContainer';
 import ImportantWeather from './importantWeather';
 import sliceElevationsWithHandles from '../modules/sliceElevationsWithHandles';
@@ -22,21 +21,10 @@ const TrailSidebar = ({firstTrail, trails, handles}) => {
     }, []);
   }
 
-  const terrain = () => {
-    if (firstTrail.hasElevationData && firstTrail.hasSatelliteImage) {
-      return <Terrain
-        index={`trail:${firstTrail.id}`}
-        satelliteImageUrl={firstTrail.satelliteImageUrl}
-        vertices={firstTrail.dump.vertices}/>
-    }
-  }
-
   const trailList = () => {
-    return <TrailListContainer trails={slicedTrails()} />
-  }
-
-  const terrainOrTrailList = () => {
-    return (trails.length > 1) ? trailList() : terrain()
+    return (<div style={{display: (trails.length > 1) ? 'block' : 'none'}}>
+      <TrailListContainer trails={slicedTrails()} />
+    </div>)
   }
 
   const elevationTotals = () => {
@@ -53,7 +41,7 @@ const TrailSidebar = ({firstTrail, trails, handles}) => {
 
   return (
     <div>
-      {terrainOrTrailList()}
+      {trailList()}
       {elevationTotals()}
       {importantWeather()}
     </div>

--- a/components/trailSidebar.js
+++ b/components/trailSidebar.js
@@ -23,12 +23,10 @@ const TrailSidebar = ({firstTrail, trails, handles}) => {
   }
 
   const terrain = () => {
-    if (firstTrail.hasElevationData) {
+    if (firstTrail.hasElevationData && firstTrail.hasSatelliteImage) {
       return <Terrain
         index={`trail:${firstTrail.id}`}
-        height={firstTrail.dump.height}
-        width={firstTrail.dump.width}
-        bounds={firstTrail.bounds}
+        satelliteImageUrl={firstTrail.satelliteImageUrl}
         vertices={firstTrail.dump.vertices}/>
     }
   }

--- a/modules/getSatelliteImage.js
+++ b/modules/getSatelliteImage.js
@@ -1,0 +1,8 @@
+import GeoViewport from '@mapbox/geo-viewport';
+
+const getSatelliteImage = ({bounds, minZoom, maxZoom}) => {
+  const {center, zoom} = GeoViewport.viewport(bounds, [1024, 1024], minZoom, maxZoom);
+  return fetch(`/api/terrain/${center.join("/")}/${zoom}`).then((r) => r.blob());
+};
+
+export default getSatelliteImage;

--- a/modules/uploadImageToS3.js
+++ b/modules/uploadImageToS3.js
@@ -1,0 +1,14 @@
+const Jimp = require('jimp');
+const AWS = require('aws-sdk');
+const s3 = new AWS.S3();
+
+const uploadImageToS3 = ({url, key, quality}) => {
+  Jimp.read(url).then(image => {
+    image.quality(quality).getBuffer(Jimp.MIME_JPEG, (err, buff) => {
+      if (err) throw err;
+      s3.putObject({Bucket: 'chrissy-gunk', Key: key, Body: buff, ACL:'public-read'});
+    });
+  });
+};
+
+exports.upload = uploadImageToS3;

--- a/server.js
+++ b/server.js
@@ -154,7 +154,7 @@ app.get('/api/terrain/:x/:y/:zoom', function(request, response){
 
   s3.headObject({Bucket: 'chrissy-gunk', Key: key}, (err, metadata) => {
     if (err && err.code == 'NotFound') {
-      response.redirect("https://" + mbHost + mbPath);
+      response.redirect("https://" + host + path);
       uploadImageToS3({host, path, key})
     } else {
       response.redirect(cachedImagePath);

--- a/state/reducers.js
+++ b/state/reducers.js
@@ -36,7 +36,7 @@ const trail = (state = {}, action) => {
       return { ...state,
         hasElevationData: true,
         geometry: lineString(points.map(p => p.coordinates)).geometry,
-        dump: action.dump,
+        vertices: action.dump.vertices,
         points: points.map((e, i) => {
           const p = points[i - 1];
           return {

--- a/state/reducers.js
+++ b/state/reducers.js
@@ -53,7 +53,6 @@ const trail = (state = {}, action) => {
     case 'SET_TRAIL_SATELLITE_IMAGE':
       if (action.id !== state.id) return state
       return {...state,
-        hasSatelliteImage: true,
         satelliteImageUrl: action.url
       }
     case 'SET_TRAIL_WEATHER_DATA':
@@ -154,7 +153,6 @@ const boundary = (state = {}, action) => {
     case 'SET_BOUNDARY_SATELLITE_IMAGE':
       if (action.id !== state.id) return state
       return {...state,
-        hasSatelliteImage: true,
         satelliteImageUrl: action.url
       }
     case 'SET_BOUNDARY_WEATHER_DATA':

--- a/state/reducers.js
+++ b/state/reducers.js
@@ -144,7 +144,7 @@ const boundary = (state = {}, action) => {
       if (action.id !== state.id) return state;
       return {...state,
         area: action.area,
-        dump: action.dump,
+        vertices: action.dump.vertices,
         trailsCount: action.trailsCount,
         trailLengths: action.trailLengths,
         trailTypes: action.trailTypes,

--- a/state/reducers.js
+++ b/state/reducers.js
@@ -50,6 +50,12 @@ const trail = (state = {}, action) => {
           }
         })
       }
+    case 'SET_TRAIL_SATELLITE_IMAGE':
+      if (action.id !== state.id) return state
+      return {...state,
+        hasSatelliteImage: true,
+        satelliteImageUrl: action.url
+      }
     case 'SET_TRAIL_WEATHER_DATA':
       if (action.id !== state.id) return state
       return { ...state,
@@ -90,6 +96,8 @@ const trails = (state = [], action) => {
       return state.map(t => trail(t, {...action, type: 'CLEAR_TRAIL_SELECTED'}))
     case 'SET_TRAIL_DATA':
       return state.map(t => trail(t, action))
+    case 'SET_TRAIL_SATELLITE_IMAGE':
+      return state.map(t => trail(t, action))
     case 'SET_TRAIL_WEATHER_DATA':
       return state.map(t => trail(t, action))
     case 'SET_TRAIL_ADDITIONAL_WEATHER_DATA':
@@ -106,6 +114,8 @@ const boundaries = (state = [], action) => {
     case 'SET_BOUNDARY_DATA':
       return state.map(b => boundary(b, action))
     case 'SET_BOUNDARY_WEATHER_DATA':
+      return state.map(b => boundary(b, action))
+    case 'SET_BOUNDARY_SATELLITE_IMAGE':
       return state.map(b => boundary(b, action))
     case 'SET_BOUNDARY_ADDITIONAL_WEATHER_DATA':
       return state.map(b => boundary(b, action))
@@ -140,6 +150,12 @@ const boundary = (state = {}, action) => {
         trailTypes: action.trailTypes,
         trails: action.trails,
         hasElevationData: true
+      }
+    case 'SET_BOUNDARY_SATELLITE_IMAGE':
+      if (action.id !== state.id) return state
+      return {...state,
+        hasSatelliteImage: true,
+        satelliteImageUrl: action.url
       }
     case 'SET_BOUNDARY_WEATHER_DATA':
       if (action.id !== state.id) return state

--- a/styles/colors.css
+++ b/styles/colors.css
@@ -12,6 +12,7 @@
   --gray-5: #A7A7A7;
   --gray-6: #838383;
   --gray-7: #494949;
+  --gray-8: #292929;
   --blue: #3232FF;
   --purple: #5700EC;
   --orange: #FF9500;

--- a/styles/terrain.css
+++ b/styles/terrain.css
@@ -1,7 +1,7 @@
 .terrain {
   width: 100%;
   height: 220px;
-  background-color: #000;
+  background-color: var(--gray-7);
   position: relative;
   grid-area: terrain;
 }
@@ -19,4 +19,10 @@
   left: 50%;
   top: 50%;
   position: absolute;
+  opacity: 0;
+  transition: .2s opacity;
+}
+
+.visible {
+  opacity: 1;
 }

--- a/styles/terrain.css
+++ b/styles/terrain.css
@@ -1,7 +1,7 @@
 .terrain {
   width: 100%;
   height: 220px;
-  background-color: var(--gray-7);
+  background-color: var(--gray-8);
   position: relative;
   grid-area: terrain;
 }
@@ -14,13 +14,18 @@
 
 .hidden { opacity: 0; }
 
-.canvas {
+.canvas, .loadingSpinner {
   transform: translateY(-50%) translateX(-50%);
   left: 50%;
   top: 50%;
   position: absolute;
   opacity: 0;
   transition: .2s opacity;
+}
+
+.loadingSpinner {
+  width: 2em;
+  height: 2em;
 }
 
 .visible {


### PR DESCRIPTION
It looks like headless GL won't be arriving for a while, and it may not be fast enough for production anyways. This pull adds a host of speed improvements to what is currently one of the slowest and most neglected parts of the app.

1. Don't wait on an s3 upload to return a new image. (duh)
2. Don't send a link to the image. just send the image (duh)
3. Fetch the image and trail data asynchronously
4. Terrain component is a persistent, root-level component that is only initiated once
5. Don't delete the mesh. Just update it
6. Limit raster sizes to 100x100
7. Heavily compress images sent to S3