### PR TITLE
Improve highlighting performance

### DIFF
--- a/components/map.js
+++ b/components/map.js
@@ -120,8 +120,14 @@ export default class Map extends React.Component {
 
   sources() {
     return [
-      {id: 'trails-selected', data: trailsToFeatureCollection(this.selectedTrails().map(t => sliceElevationsWithHandles(t, this.props.handles)))},
-      {id: 'handles', data: featureCollection(this.props.handles.map(p => pointToPoint(p)))}
+      {
+        id: 'trails-selected',
+        data: trailsToFeatureCollection(this.selectedTrails().map(t => sliceElevationsWithHandles(t, this.props.handles)))
+      },
+      {
+        id: 'handles',
+        data: featureCollection(this.props.handles.map(p => pointToPoint(p)))
+      }
     ];
   }
 

--- a/components/mapBox.js
+++ b/components/mapBox.js
@@ -63,7 +63,7 @@ export default class MapBox extends React.PureComponent {
           features: (event.point) ? this.mapboxed.queryRenderedFeatures(event.point, { layers: this.props.watchLayers }) : null
         });
         this.props[eventName](eventMod);
-      }, 10, {leading: true}));
+      }, 2, {leading: true}));
     });
   }
 

--- a/components/mapBox.js
+++ b/components/mapBox.js
@@ -6,13 +6,12 @@ import helpers from '@turf/helpers';
 import {accessToken, styleUrl} from '../modules/mapboxStaticData';
 import styles from '../styles/mapbox.css';
 import mapboxStyles from '../public/dist/mapbox-styles.json';
-import throttle from 'lodash.throttle';
+import debounce from 'lodash.debounce';
 const WATCH_EVENTS = ['mousedown','mouseup','click','dblclick','mousemove','mouseenter', 'mouseleave','mouseover','mouseout','contextmenu','touchstart','touchend','touchcancel'];
 
 export default class MapBox extends React.PureComponent {
 
   updateSources(oldSources = [], newSources = []) {
-    console.log(newSources)
     newSources.forEach(function(source) {
       this.mapboxed.getSource(source.id).setData(source.data);
     }.bind(this))
@@ -59,12 +58,12 @@ export default class MapBox extends React.PureComponent {
     WATCH_EVENTS.forEach((eventName) => {
       if (!this.props[eventName]) return;
 
-      this.mapboxed.on(eventName, throttle((event) => {
+      this.mapboxed.on(eventName, debounce((event) => {
         const eventMod = Object.assign({}, event, {
           features: (event.point) ? this.mapboxed.queryRenderedFeatures(event.point, { layers: this.props.watchLayers }) : null
         });
         this.props[eventName](eventMod);
-      }, 100, true));
+      }, 10, {leading: true}));
     });
   }
 

--- a/components/mapBox.js
+++ b/components/mapBox.js
@@ -1,4 +1,5 @@
 import React, { Proptypes } from 'react';
+import {fromJS, is} from 'immutable';
 import MapboxGL from 'mapbox-gl';
 import bbox from '@turf/bbox';
 import helpers from '@turf/helpers';
@@ -11,6 +12,7 @@ const WATCH_EVENTS = ['mousedown','mouseup','click','dblclick','mousemove','mous
 export default class MapBox extends React.PureComponent {
 
   updateSources(oldSources = [], newSources = []) {
+    console.log(newSources)
     newSources.forEach(function(source) {
       this.mapboxed.getSource(source.id).setData(source.data);
     }.bind(this))
@@ -38,7 +40,9 @@ export default class MapBox extends React.PureComponent {
   }
 
   componentDidUpdate(prevProps, q) {
-    this.updateSources(prevProps.sources, this.props.sources);
+    if (!is(fromJS(prevProps.sources), fromJS(this.props.sources))) {
+      this.updateSources(prevProps.sources, this.props.sources);
+    }
 
     if (this.props.filters && prevProps.filters !== this.props.filters) {
       this.updateFilters(this.props.filters);

--- a/components/sidebar.js
+++ b/components/sidebar.js
@@ -18,6 +18,7 @@ const Sidebar = ({trails, boundary, handles}) => {
   }
 
   const terrain = () => {
+    return null;
     return <Terrain
       satelliteImageUrl={(trails[0] || boundary || {}).satelliteImageUrl}
       points={(slicedTrails()[0] || {}).points}

--- a/components/sidebar.js
+++ b/components/sidebar.js
@@ -18,7 +18,6 @@ const Sidebar = ({trails, boundary, handles}) => {
   }
 
   const terrain = () => {
-    return null;
     return <Terrain
       satelliteImageUrl={(trails[0] || boundary || {}).satelliteImageUrl}
       points={(slicedTrails()[0] || {}).points}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,7 +19,9 @@ gulp.task('mapify', () => {
     json.sources = json[tileSource];
     json.layers = json.layers.map(l => {
       const source = (tileSource == "local") ? "local" : "composite"
+      const sourceHover = (tileSource == "local") ? "localHover" : "compositeHover"
       l.source = (l.source == "$source") ? source : l.source;
+      l.source = (l.source == "$sourceHover") ? sourceHover : l.source;
       return l;
     });
     return json;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5571,6 +5571,11 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+    },
     "lodash.escape": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4934,6 +4934,11 @@
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
       "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
     },
+    "immutable": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
+    },
     "indexes-of": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "gulp-json-editor": "^2.4.1",
     "gulp-merge-json": "^1.3.1",
     "gulp-plumber": "^1.2.0",
+    "immutable": "^3.8.2",
     "isomorphic-fetch": "^2.2.1",
     "jimp": "^0.2.28",
     "jsonfile": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "isomorphic-fetch": "^2.2.1",
     "jimp": "^0.2.28",
     "jsonfile": "^3.0.0",
+    "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",
     "mapbox-gl": "^0.45.0",
     "moment": "^2.22.1",

--- a/styles/base.json
+++ b/styles/base.json
@@ -17,6 +17,16 @@
       "tiles": ["http://localhost:5000/tiles/{z}/{x}/{y}.pbf"],
       "type": "vector"
     },
+    "compositeHover": {
+      "url": "mapbox://mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v7,fivefourths.park-boundaries,fivefourths.park-boundary-labels",
+      "type": "vector",
+      "tolerance": 100
+    },
+    "localHover": {
+      "tiles": ["http://localhost:5000/tiles/{z}/{x}/{y}.pbf"],
+      "type": "vector",
+      "tolerance": 100,
+    },
     "handles": {
       "data": {
         "type": "FeatureCollection",
@@ -34,6 +44,10 @@
   },
   "remote": {
     "composite": {
+      "url": "mapbox://mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v7,fivefourths.park-boundaries,fivefourths.local",
+      "type": "vector"
+    },
+    "compositeHover": {
       "url": "mapbox://mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v7,fivefourths.park-boundaries,fivefourths.local",
       "type": "vector"
     },

--- a/styles/base.json
+++ b/styles/base.json
@@ -18,14 +18,12 @@
       "type": "vector"
     },
     "compositeHover": {
-      "url": "mapbox://mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v7,fivefourths.park-boundaries,fivefourths.park-boundary-labels",
-      "type": "vector",
-      "tolerance": 100
+      "url": "fivefourths.park-boundary-labels",
+      "type": "vector"
     },
     "localHover": {
       "tiles": ["http://localhost:5000/tiles/{z}/{x}/{y}.pbf"],
-      "type": "vector",
-      "tolerance": 100,
+      "type": "vector"
     },
     "handles": {
       "data": {
@@ -48,7 +46,7 @@
       "type": "vector"
     },
     "compositeHover": {
-      "url": "mapbox://mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v7,fivefourths.park-boundaries,fivefourths.local",
+      "url": "fivefourths.park-boundary-labels,fivefourths.local",
       "type": "vector"
     },
     "handles": {

--- a/styles/base.json
+++ b/styles/base.json
@@ -10,15 +10,11 @@
   "pitch": 0,
   "local": {
     "composite": {
-      "url": "mapbox://mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v7,fivefourths.park-boundaries,fivefourths.park-boundary-labels",
+      "url": "mapbox://mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v7,fivefourths.park-boundaries",
       "type": "vector"
     },
     "local": {
       "tiles": ["http://localhost:5000/tiles/{z}/{x}/{y}.pbf"],
-      "type": "vector"
-    },
-    "compositeHover": {
-      "url": "fivefourths.park-boundary-labels",
       "type": "vector"
     },
     "localHover": {
@@ -46,7 +42,7 @@
       "type": "vector"
     },
     "compositeHover": {
-      "url": "fivefourths.park-boundary-labels,fivefourths.local",
+      "url": "fivefourths.local",
       "type": "vector"
     },
     "handles": {

--- a/styles/park-labels.json
+++ b/styles/park-labels.json
@@ -12,6 +12,8 @@
       "stops": [[9, 10],[10, 11],[18, 14]]
     },
     "text-offset": [0, 0.5],
+    "text-allow-overlap": true,
+    "icon-allow-overlap": true,
     "text-anchor": "top",
     "text-font": ["DIN Offc Pro Medium","Arial Unicode MS Regular"],
     "text-field": "{name}",
@@ -36,6 +38,8 @@
   "layout": {
     "icon-image": "park-11",
     "icon-size": 0.8,
+    "icon-allow-overlap": true,
+    "text-allow-overlap": true,
     "text-line-height": 1.1,
     "text-size": {
       "base": 1,
@@ -55,5 +59,5 @@
     "text-halo-blur": 0.5
   },
   "interactive": true,
-  "filter": ["in", "id", 0]
+  "filter": ["all", ["in", "id", 0], [">", "area", 500000000]]
 }]}

--- a/styles/park-labels.json
+++ b/styles/park-labels.json
@@ -1,7 +1,7 @@
 {"layers": [{
   "id": "national-park-labels",
   "type": "symbol",
-  "source": "$sourceHover",
+  "source": "$source",
   "source-layer": "park-boundary-labels",
   "layout": {
     "icon-image": "park-11",
@@ -24,6 +24,7 @@
     "text-halo-width": 0.5,
     "text-halo-blur": 0.5
   },
+  "interactive": true,
   "filter": [">", "area", 500000000]
 },
 {
@@ -53,5 +54,6 @@
     "text-halo-width": 0.5,
     "text-halo-blur": 0.5
   },
+  "interactive": true,
   "filter": ["in", "id", 0]
 }]}

--- a/styles/park-labels.json
+++ b/styles/park-labels.json
@@ -1,7 +1,7 @@
 {"layers": [{
   "id": "national-park-labels",
   "type": "symbol",
-  "source": "$source",
+  "source": "$sourceHover",
   "source-layer": "park-boundary-labels",
   "layout": {
     "icon-image": "park-11",
@@ -29,7 +29,7 @@
 {
   "id": "national-park-labels-active",
   "type": "symbol",
-  "source": "$source",
+  "source": "$sourceHover",
   "text-ignore-placement": false,
   "source-layer": "park-boundary-labels",
   "layout": {

--- a/styles/trails.json
+++ b/styles/trails.json
@@ -129,7 +129,7 @@
 },
 {
   "id": "trails-preview",
-  "source": "$source",
+  "source": "$sourceHover",
   "source-layer": "trails",
   "filter": ["in", "id", 0],
   "type": "line",
@@ -150,7 +150,7 @@
   "type": "line",
   "paint": {
     "line-color": "transparent",
-    "line-width": 15
+    "line-width": 8
   },
   "filter": ["in", "type", "hike", "horse", "bike", "atv", "motorcycle", "trail"]
 },

--- a/styles/trails.json
+++ b/styles/trails.json
@@ -138,6 +138,7 @@
     "line-cap": "round",
     "line-join": "bevel"
   },
+  "interactive": true,
   "paint": {
     "line-color": "#FF9100",
     "line-width": 2
@@ -152,6 +153,7 @@
     "line-color": "transparent",
     "line-width": 8
   },
+  "interactive": true,
   "filter": ["in", "type", "hike", "horse", "bike", "atv", "motorcycle", "trail"]
 },
 {
@@ -165,7 +167,8 @@
   "paint": {
     "line-color": "#FFF",
     "line-width": 4
-  }
+  },
+  "interactive": true
 },
 {
   "id": "trails-selected",
@@ -178,7 +181,8 @@
   "paint": {
     "line-color": "#FF9100",
     "line-width": 2
-  }
+  },
+  "interactive": true
 },
 {
   "id": "handles-outline",
@@ -187,7 +191,8 @@
   "paint": {
     "circle-radius": 6,
     "circle-color": "#FFF"
-  }
+  },
+  "interactive": true
 },
 {
   "id": "trail-labels",


### PR DESCRIPTION
- Improve highlighting performance on trails and labels by moving active state layers to a separate source
- fix a very annoying bug with collision and hover states
- switch from throttle to debounce and shorten interval for major uptick in perceived speed
- don't always call `setSource`. use `immutable` to do deep comparison on sources before calling.